### PR TITLE
refact: rename cronSpec to cronRule

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,14 +19,12 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	enableCron        bool
 	enableWebhook     bool
 	kubeconfig        string
 	locoAPIKeys       map[string]string
+	schedule          string
 	tlsCertFile       string
 	tlsPrivateKeyFile string
-
-	cronSpec string
 }
 
 // App represents the main application object
@@ -74,9 +72,9 @@ func (app *App) Run() {
 	// compute translation hashes
 	hashes := app.translations.Fetch()
 
-	if app.config.enableCron {
+	if app.config.schedule != "" {
 		cron := cron.New()
-		_, _ = cron.AddFunc(app.config.cronSpec, func() {
+		_, _ = cron.AddFunc(app.config.schedule, func() {
 			// make sure we have the latest translations
 			app.translations.Fetch()
 			// update kubernetes deployments

--- a/main.go
+++ b/main.go
@@ -12,11 +12,9 @@ import (
 
 func main() {
 	var (
-		kubeconfig    *string
-		enableCron    *bool
 		enableWebhook *bool
-
-		cronSpec *string
+		kubeconfig    *string
+		schedule      *string
 	)
 
 	// Kubeconfig flag
@@ -26,25 +24,22 @@ func main() {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 
-	// Boolean flags
-	enableCron = flag.Bool("cron", true, "Enable periodic translations refreshes in the backgound")
 	enableWebhook = flag.Bool("webhook", false, "Enable mutation webhook endpoint")
-
-	// Cron rule flag
-	cronSpec = flag.String("cronSpec", "*/2 * * * *", "Cron of the translations refreshes")
+	schedule = flag.String("schedule", "", "Cron schedule expression of the translations refreshes")
 
 	flag.Parse()
 
-	_, err := cron.ParseStandard(*cronSpec)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cron flag cannot be parsed: %s", err)
+	if *schedule != "" {
+		_, err := cron.ParseStandard(*schedule)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "-schedule flag cannot be parsed: %s", err)
+		}
 	}
 
 	config := &Config{
-		enableCron:    *enableCron,
 		enableWebhook: *enableWebhook,
 		kubeconfig:    *kubeconfig,
-		cronSpec:      *cronSpec,
+		schedule:      *schedule,
 
 		locoAPIKeys: map[string]string{
 			"catalog":   os.Getenv("LOCO_API_KEY_CATALOG"),


### PR DESCRIPTION
Talking about _cron rule_ instead _cron spec_ should be better